### PR TITLE
Move the arculator21.tar.gz to the redirected location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build/emu: dlcache/arculator21.tar.gz
 
 dlcache/arculator21.tar.gz:
 	mkdir -p dlcache
-	curl -s http://b-em.bbcmicro.com/arculator/Arculator_V2.1_Linux.tar.gz --output dlcache/arculator21.tar.gz
+	curl -s https://b-em.bbcmicro.com/arculator/Arculator_V2.1_Linux.tar.gz --output dlcache/arculator21.tar.gz
 
 build/software/software.json:
 	arclive-software/toml2json.py arclive-software/catalogue/ build/software/


### PR DESCRIPTION
The origin server is doing an http->https redirect, but the `curl` invocation isn't following it.  That breaks `make` on first use.  This patch just changes the URL to the new location without telling `curl` to follow redirects.  Calling `make` now gets past that step, but fails somewhere else.