### PR TITLE
Add requests as a python dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ toml
 tomlkit
 s3cmd
 jinja2-cli
+requests


### PR DESCRIPTION
Missed `requests` dependency means that `arclive-software/toml2json.py` fails.  Arguably there should be a `requirements.txt` in `arclive-software` but this gets the build past that step.